### PR TITLE
Add file extension to Strixhaven pack images

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -120,7 +120,7 @@ export const BOOSTER_ARTS = {
   m21: ['https://i.imgur.com/S1cOF9i.png', 'https://i.imgur.com/LKevS2s.png', 'https://i.imgur.com/OXmGYuW.png'],
   znr: ['https://i.imgur.com/iQNIacv.png', 'https://i.imgur.com/WrqzTn9.png', 'https://i.imgur.com/I1MTTbw.png'],
   khm: ['https://i.imgur.com/txY0DnA.png', 'https://i.imgur.com/dqITFAO.png', 'https://i.imgur.com/HMJwSS4.png', 'https://i.imgur.com/8dOokeV.png'],
-  stx: ['https://imgur.com/dzwWkKj', 'https://imgur.com/MDs10oK', 'https://imgur.com/fsbFroX', 'https://imgur.com/9xB8VRN', 'https://imgur.com/JW6wvPX'],
+  stx: ['https://imgur.com/dzwWkKj.png', 'https://imgur.com/MDs10oK.png', 'https://imgur.com/fsbFroX.png', 'https://imgur.com/9xB8VRN.png', 'https://imgur.com/JW6wvPX.png'],
   afr: ['https://i.imgur.com/aoxiVmL.png', 'https://i.imgur.com/wbOLpec.png', 'https://i.imgur.com/PQR9n5W.png', 'https://i.imgur.com/WvXFbJr.png'],
   mh2: ['https://i.imgur.com/V7UlQ5T.png', 'https://i.imgur.com/k0l1Mrm.png', 'https://i.imgur.com/fdtjZg9.png'],
   vow: ['https://i.imgur.com/S3v5ZVd.png'],


### PR DESCRIPTION
These missing extensions were causing issues for me when importing Strixhaven packs into tts.